### PR TITLE
Cam796 - Update map page

### DIFF
--- a/frontend/src/components/ForecastPlot.vue
+++ b/frontend/src/components/ForecastPlot.vue
@@ -1,5 +1,26 @@
 <template>
   <v-card v-if="show" class="mx-auto" elevation="8" style="height: calc(30vh); width: 100%">
+    <div class="position-absolute" style="top: 6px; right: 8px; z-index: 2;">
+      <InfoIcon
+        content-class="plot-info-tooltip"
+        :z-index="200000" 
+        :max-width="420"
+        style="margin-left: 4px"
+        text="This graph shows streamflow (in cubic feet per second) forecasted over the
+        next 10 days.  
+        If you see a high flow on this graph, and would like more information on flood
+        risk in this area, please visit water.noaa.gov to view Flood Impact Statements 
+        (for guidance, go to FloodSavvy's RESOURCES page) or consider contacting the local
+        National Weather Forecast Office. If this graph has a zero value, this means the
+        river you selected is intermittent, and only has brief periods of streamflow after
+        heavy rainfall occurs upstream. 
+        This data comes from the medium-range simulations of the National Water Model. 
+        The forecast shown here represents just one possible scenario, extending out to 10 days.
+        To learn more about how this information is modeled or how to access and retrieve the data, 
+        please visit: 
+        https://www.sciencedirect.com/science/article/pii/S1364815224001841"
+      />
+    </div>
     <v-skeleton-loader v-if="isLoading" type="heading, image " :loading="isLoading" class="mx-auto"></v-skeleton-loader>
     <v-row v-if="isLoading" justify="center" align="center" class="mt-4">
       <v-progress-circular indeterminate color="primary" size="40"></v-progress-circular>
@@ -27,6 +48,7 @@ import LinePlot from '@/components/LinePlot.vue'
 import { ref, defineExpose } from 'vue'
 import { API_BASE } from '@/constants'
 import { mdiCodeJson } from '@mdi/js'
+import InfoIcon from '@/components/InfoTooltip.vue'
 import {
   Chart as ChartJS,
   Title,
@@ -130,4 +152,5 @@ defineProps({
   white-space: normal;
   word-break: normal;
 }
+
 </style>

--- a/frontend/src/components/HistoricalPlot.vue
+++ b/frontend/src/components/HistoricalPlot.vue
@@ -1,12 +1,28 @@
 <template>
   <v-card v-if="show" class="mx-auto" elevation="8" style="height: calc(30vh); width: 100%">
+    <div class="position-absolute" style="top: 6px; right: 8px; z-index: 2;">
+      <InfoIcon
+        content-class="plot-info-tooltip"
+        :z-index="200000" 
+        :max-width="420"
+        style="margin-left: 4px"
+        text="This graph shows streamflow (in cubic feet per second) for the past 90 days. 
+        You can explore a different timeframe by clicking the button in the bottom-right 
+        corner and adjusting the start and end dates. This data is sourced from the analysis
+        and assimilation simulation of the National Water Model, which combines observed data 
+        with model simulations to generate the most accurate estimates of current conditions. 
+        To learn more about how this information is modeled or how to access and retrieve the data, 
+        please visit: 
+        https://www.sciencedirect.com/science/article/pii/S1364815224001841"
+      />
+    </div>
     <v-skeleton-loader v-if="isLoading" type="heading, image " :loading="isLoading" class="mx-auto"></v-skeleton-loader>
     <v-row v-if="isLoading" justify="center" align="center" class="mt-4">
       <v-progress-circular indeterminate color="primary" size="40"></v-progress-circular>
       <span class="ml-3">Loading historical data...</span>
     </v-row>
     <LinePlot v-if="!isLoading" :timeseries="plot_timeseries" :title="plot_title" :style="plot_style" />
-    <v-card-actions class="position-relative">
+    <v-card-actions class="position-relative">      
       <v-tooltip location="bottom" max-width="200px" class="chart-tooltip">
         <template #activator="{ props }">
           <v-btn v-bind="props" v-if="plot_timeseries.length > 0 && !isLoading" color="primary"
@@ -27,6 +43,7 @@ import LinePlot from '@/components/LinePlot.vue'
 import { ref, defineExpose } from 'vue'
 import { API_BASE } from '@/constants'
 import { mdiCodeJson } from '@mdi/js'
+import InfoIcon from '../components/InfoTooltip.vue'
 import {
   Chart as ChartJS,
   Title,
@@ -129,4 +146,5 @@ defineProps({
   white-space: normal;
   word-break: normal;
 }
+
 </style>

--- a/frontend/src/components/InfoTooltip.vue
+++ b/frontend/src/components/InfoTooltip.vue
@@ -1,21 +1,37 @@
 <template>
-  <v-tooltip location="bottom" max-width="200px" style="white-space: normal">
-    <template #activator="{ props }">
+  <v-tooltip
+    :location="location"
+    :max-width="maxWidth"
+    :content-class="contentClass"
+    :z-index="zIndex"
+  >
+    <template #activator="{ props: act }">
       <v-icon
-        v-bind="props"
+        v-bind="act"
         :icon="mdiInformationOutline"
         color="info"
-        style="cursor: pointer; margin-left: 10px"
-      >
-      </v-icon>
+        class="cursor-pointer ml-2"
+      />
     </template>
-    <div>{{ props.text }}</div>
+
+    <div class="whitespace-normal">{{ text }}</div>
   </v-tooltip>
 </template>
 
 <script setup>
 import { mdiInformationOutline } from '@mdi/js'
-const props = defineProps({
-  text: { type: String, default: '' }
+
+const { text, contentClass, zIndex, location, maxWidth } = defineProps({
+  text: { type: String, default: '' },
+  contentClass: { type: String, default: '' }, // lets us target the teleported overlay
+  zIndex: { type: [Number, String], default: 200000 }, // render above plot container (99999)
+  location: { type: String, default: 'bottom' },
+  maxWidth: { type: [Number, String], default: 200 }
 })
 </script>
+
+<style scoped>
+.whitespace-normal { white-space: normal; }
+.ml-2 { margin-left: 10px; }
+.cursor-pointer { cursor: pointer; }
+</style>

--- a/frontend/src/views/ContactView.vue
+++ b/frontend/src/views/ContactView.vue
@@ -1,8 +1,9 @@
 <template>
-  <h2 class="ma-2 text-center">Contact</h2>
+  
   <v-container class="about">
-    <v-sheet class="pa-6 mx-auto" max-width="1200" rounded>
-      <p>
+    <v-sheet class="px-6 pt-6 pb-0 mx-auto" max-width="1200" rounded>
+      <h3 class="mt-2 mb-2">Contact Information</h3>
+      <p class="mt-0 mb-0">
         This project is a collaboration between the
         <a href="https://globalresilience.northeastern.edu/"
           >Global Resilience Institute at Northeastern University</a
@@ -19,8 +20,8 @@
       </p>
     </v-sheet>
 
-    <v-sheet class="pa-6 mx-auto" max-width="1200" rounded>
-      <h2 class="ma-2 text-center">Our Team</h2>
+    <v-sheet class="px-6 pt-2 pb-6 mx-auto" max-width="1200" rounded>
+      <h3 class="mt-0 mb-2">Our Team</h3>
       <v-row align="center" justify="center">
         <v-col
           v-for="member in members"
@@ -129,7 +130,7 @@ const members = [
   {
     name: 'Emma Hibbert',
     image: emmaImg,
-    position: 'Research Associate',
+    position: 'Senior Research Associate',
     org: 'Global Resilience Institute',
     email: 'e.hibbert@northeastern.edu'
   },

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -22,7 +22,8 @@
         >
           Historical
           <InfoIcon
-            text="Plot historical streamflow data for the selected river reach."
+            text="Display historical streamflow data for the selected river as a graph, 
+            showing hourly values in cubic feet per second (cfs)."
             style="margin-left: 5px"
           />
         </v-btn>
@@ -33,7 +34,8 @@
         >
           Forecast
           <InfoIcon
-            text="Plot forecasted streamflow data for the selected river reach."
+            text="Display forecasted streamflow data for selected river or stream in a graph,
+            showing hourly values in cubic feet per second (cfs)."
             style="margin-left: 5px"
           />
         </v-btn>


### PR DESCRIPTION
The changes include:
- Adding popup information for both historical and forecast plots
- Modifying the tooltip styling to ensure the popup text is not hidden by plots

The info tooltips are now located in the top-right corner of the plots. Since Tony’s PR (#83) also places the date-range adjustment button there, we may want to coordinate on the best placement.