### PR TITLE
CAM928: Enforce layer ordering for waterbodies and points of interest

### DIFF
--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -97,6 +97,12 @@ onMounted(() => {
     zoomDelta: 1,
     zoomControl: false
   }).setView([38.2, -96], 5)
+
+  leaflet.value.createPane('paneWaterbodies')
+  leaflet.value.getPane('paneWaterbodies').style.zIndex = 450
+  leaflet.value.createPane('panePOI')
+  leaflet.value.getPane('panePOI').style.zIndex = 500
+
   mapObject.value.hucbounds = []
   mapObject.value.popups = []
   mapObject.value.buffer = 20

--- a/frontend/src/helpers/map.js
+++ b/frontend/src/helpers/map.js
@@ -374,7 +374,12 @@ async function createWMSLayers(region) {
       }
       const wmsLayer = esriLeaflet.dynamicMapLayer({
         url: url,
-        pane: 'overlayPane',
+        pane:
+          layer.name.includes("Points of Interest")
+            ? "panePOI"
+            : layer.name.includes("Waterbodies")
+            ? "paneWaterbodies"
+            : "overlayPane",
         layers: [layer.id],
         transparent: true,
         format: 'image/png',


### PR DESCRIPTION
This layer ordering fixes the issue where flowlines and points of interest sometimes render above waterbodies. 

- Added custom panes with zIndex for both waterbodies and POIs
- Updated WMS layer creation 